### PR TITLE
DVBKindの引数はデフォルト引数にせず必ず呼び出し側が指定する

### DIFF
--- a/mythtv/libs/libmythtv/mpeg/dvbdescriptors.h
+++ b/mythtv/libs/libmythtv/mpeg/dvbdescriptors.h
@@ -40,7 +40,7 @@ static QString coderate_inner(uint coderate);
 class DVBDescriptor : public MPEGDescriptor
 {
   public:
-    DVBDescriptor(const unsigned char *data, DVBKind dvbkind = kKindUnknown, int len = 300, uint tag = NULL)
+    DVBDescriptor(const unsigned char *data, DVBKind dvbkind, int len = 300, uint tag = 0)
         : MPEGDescriptor(data, len, tag), _dvbkind(dvbkind)
     {
         if ((len < 2) || (int(DescriptorLength()) + 2) > len)

--- a/mythtv/libs/libmythtv/mpeg/dvbstreamdata.cpp
+++ b/mythtv/libs/libmythtv/mpeg/dvbstreamdata.cpp
@@ -18,7 +18,7 @@ using namespace std;
 
 // service_id is synonymous with the MPEG program number in the PMT.
 DVBStreamData::DVBStreamData(uint desired_netid,  uint desired_tsid,
-                             int desired_program, int cardnum, bool cacheTables, DVBKind dvbkind)
+                             int desired_program, int cardnum, DVBKind dvbkind, bool cacheTables)
     : MPEGStreamData(desired_program, cardnum, cacheTables),
       _desired_netid(desired_netid), _desired_tsid(desired_tsid),
       _dvbkind(dvbkind),

--- a/mythtv/libs/libmythtv/mpeg/dvbstreamdata.h
+++ b/mythtv/libs/libmythtv/mpeg/dvbstreamdata.h
@@ -27,8 +27,7 @@ class MTV_PUBLIC DVBStreamData : virtual public MPEGStreamData
 {
   public:
     DVBStreamData(uint desired_netid, uint desired_tsid,
-                  int desired_program, int cardnum, bool cacheTables = false,
-                  DVBKind dvbkind = kKindDVB);
+                  int desired_program, int cardnum, DVBKind dvbkind, bool cacheTables = false);
     virtual ~DVBStreamData();
 
     using MPEGStreamData::Reset;

--- a/mythtv/libs/libmythtv/mpeg/scanstreamdata.cpp
+++ b/mythtv/libs/libmythtv/mpeg/scanstreamdata.cpp
@@ -4,10 +4,10 @@
 #include "atsctables.h"
 #include "dvbtables.h"
 
-ScanStreamData::ScanStreamData(bool no_default_pid, DVBKind dvbkind) :
+ScanStreamData::ScanStreamData(DVBKind dvbkind, bool no_default_pid) :
     MPEGStreamData(-1, -1, true),
     ATSCStreamData(-1, -1, -1, true),
-    DVBStreamData(0, 0, -1, -1, true, dvbkind),
+    DVBStreamData(0, 0, -1, -1, dvbkind, true),
     dvb_uk_freesat_si(false),
     m_no_default_pid(no_default_pid)
 {

--- a/mythtv/libs/libmythtv/mpeg/scanstreamdata.h
+++ b/mythtv/libs/libmythtv/mpeg/scanstreamdata.h
@@ -13,7 +13,7 @@ class MTV_PUBLIC ScanStreamData :
     public DVBStreamData
 {
   public:
-    ScanStreamData(bool no_default_pid = false, DVBKind dvbkind = kKindDVB);
+    ScanStreamData(DVBKind dvbkind, bool no_default_pid = false);
     virtual ~ScanStreamData();
 
     bool IsRedundant(uint pid, const PSIPTable&) const;

--- a/mythtv/libs/libmythtv/tv_rec.cpp
+++ b/mythtv/libs/libmythtv/tv_rec.cpp
@@ -1879,10 +1879,10 @@ bool TVRec::SetupDTVSignalMonitor(bool EITscan)
                     dvbkind = kKindISDB;
                 else
                     dvbkind = kKindDVB;
-                sd = dsd = new DVBStreamData(netid, tsid, progNum, cardid, false, dvbkind);
+                sd = dsd = new DVBStreamData(netid, tsid, progNum, cardid, dvbkind);
             }
             else
-                sd = dsd = new DVBStreamData(netid, tsid, progNum, cardid);
+                sd = dsd = new DVBStreamData(netid, tsid, progNum, cardid, kKindUnknown);
             sd->SetCaching(true);
             if (GetDTVRecorder())
                 GetDTVRecorder()->SetStreamData(dsd);

--- a/mythtv/programs/mythutil/mpegutils.cpp
+++ b/mythtv/programs/mythutil/mpegutils.cpp
@@ -750,7 +750,7 @@ static int pid_printer(const MythUtilCommandLineParser &cmdline)
     bool autopts = !cmdline.toBool("noautopts");
     bool use_xml = cmdline.toBool("xml");
 
-    ScanStreamData *sd = new ScanStreamData(true);
+    ScanStreamData *sd = new ScanStreamData(kKindUnknown, true);
     for (QHash<uint,bool>::iterator it = use_pid.begin();
          it != use_pid.end(); ++it)
     {


### PR DESCRIPTION
メソッド引数が
  foo(bool flag=false, DVBKind dvbkind=kKindDVB)
のように宣言されており、
foo(kKindDVB) の呼び出しが foo(true, kKindDVB) と
解釈されてしまっている箇所がありました。
そのような引数渡しミスがコンパイラによって検出されるように、
DVBKindのデフォルト引数をやめる変更です。
引数の順序も変えていますが、結果的にこれで適切な呼び出しに
なっていると思います。
チャンネルスキャンでチャンネルがDVBではなくMPEGと認識されるのも
これで解消されるのではと思いますが、手元では本家のfixes/0.27をマージしたうえで
作業しているのでそこははっきりしないです。
