### PR TITLE
地デジ放送に合わせて受信パラメータを修正

### DIFF
--- a/mythtv/libs/libmythtv/frequencytables.cpp
+++ b/mythtv/libs/libmythtv/frequencytables.cpp
@@ -485,13 +485,13 @@ static void init_freq_tables(freq_table_map_t &fmap)
 
     // Japan (ISDB-T)
     fmap["dvbt_ofdm_jp0"] = new FrequencyTable(
-       473142857, 803142857, 6000000, "Channel %1", 13,
+        473142857, 803142857, 6000000, "Channel %1", 13,
         DTVInversion::kInversionAuto,
-        DTVBandwidth::kBandwidth6MHz, DTVCodeRate::kFECAuto,
-        DTVCodeRate::kFECAuto, DTVModulation::kModulationQAM64,
-        DTVTransmitMode::kTransmissionMode2K,
-        DTVGuardInterval::kGuardInterval_1_16, DTVHierarchy::kHierarchyNone,
-        DTVModulation::kModulationQAM64, 0, -0);
+        DTVBandwidth::kBandwidth6MHz, DTVCodeRate::kFEC_3_4,
+        DTVCodeRate::kFEC_3_4, DTVModulation::kModulationQAM64,
+        DTVTransmitMode::kTransmissionMode8K,
+        DTVGuardInterval::kGuardInterval_1_8, DTVHierarchy::kHierarchyNone,
+        DTVModulation::kModulationQAM64, 0, 0);
 
     // DVB-C Germany
     fmap["dvbc_qam_de0"] = new FrequencyTable(


### PR DESCRIPTION
日本向けの受信パラメータを、地デジ放送の実際の運用で使用されている（らしい）ものに変更してみました。
この設定が適切という自信があるわけではないのと、とくにこれで何か改善されるということも無いと思うので、
気が向いたら使ってくださいという感じです。
